### PR TITLE
Alternate logon

### DIFF
--- a/contrib/win32/win32compat/pwd.c
+++ b/contrib/win32/win32compat/pwd.c
@@ -269,6 +269,8 @@ get_passwd(const wchar_t * user_utf16, PSID sid)
 
 cleanup:
 
+	if (user_utf16_modified)
+		free(user_utf16_modified);
 	if (sid_string)
 		LocalFree(sid_string);
 	if (reg_key)

--- a/contrib/win32/win32compat/win32_usertoken_utils.c
+++ b/contrib/win32/win32compat/win32_usertoken_utils.c
@@ -812,13 +812,13 @@ windows_password_auth(const char *username, const char* password)
 	}
 
 	if (pLogonUserExExW(unam_utf16, udom_utf16, pwd_utf16, LOGON32_LOGON_INTERACTIVE,
-		LOGON32_PROVIDER_DEFAULT, NULL, &token, NULL, NULL, NULL, NULL) == TRUE) {
+		LOGON32_PROVIDER_WINNT50, NULL, &token, NULL, NULL, NULL, NULL) == TRUE) {
 		password_auth_token = token;
 		debug("Password-based logon (interactive) succeeded for user: %ls domain: %ls",
 			unam_utf16, udom_utf16);
 	} else if (GetLastError() ==  ERROR_LOGON_TYPE_NOT_GRANTED && 
 		pLogonUserExExW(unam_utf16, udom_utf16, pwd_utf16, LOGON32_LOGON_NETWORK_CLEARTEXT,
-		LOGON32_PROVIDER_DEFAULT, NULL, &token, NULL, NULL, NULL, NULL) == TRUE) {
+		LOGON32_PROVIDER_WINNT50, NULL, &token, NULL, NULL, NULL, NULL) == TRUE) {
 		debug("Password-based logon (network) succeeded for user: %ls domain: %ls",
 			unam_utf16, udom_utf16);
 		password_auth_token = token;

--- a/contrib/win32/win32compat/win32_usertoken_utils.c
+++ b/contrib/win32/win32compat/win32_usertoken_utils.c
@@ -811,10 +811,18 @@ windows_password_auth(const char *username, const char* password)
 		}
 	}
 
-	if (pLogonUserExExW(unam_utf16, udom_utf16, pwd_utf16, LOGON32_LOGON_NETWORK_CLEARTEXT,
-		LOGON32_PROVIDER_DEFAULT, NULL, &token, NULL, NULL, NULL, NULL) == TRUE)
+	if (pLogonUserExExW(unam_utf16, udom_utf16, pwd_utf16, LOGON32_LOGON_INTERACTIVE,
+		LOGON32_PROVIDER_DEFAULT, NULL, &token, NULL, NULL, NULL, NULL) == TRUE) {
 		password_auth_token = token;
-	else {
+		debug("Password-based logon (interactive) succeeded for user: %ls domain: %ls",
+			unam_utf16, udom_utf16);
+	} else if (GetLastError() ==  ERROR_LOGON_TYPE_NOT_GRANTED && 
+		pLogonUserExExW(unam_utf16, udom_utf16, pwd_utf16, LOGON32_LOGON_NETWORK_CLEARTEXT,
+		LOGON32_PROVIDER_DEFAULT, NULL, &token, NULL, NULL, NULL, NULL) == TRUE) {
+		debug("Password-based logon (network) succeeded for user: %ls domain: %ls",
+			unam_utf16, udom_utf16);
+		password_auth_token = token;
+	} else {
 		if (GetLastError() == ERROR_PASSWORD_MUST_CHANGE)
 			/*
 			* TODO - need to add support to force password change


### PR DESCRIPTION
Allow password-based logon to prefer interactive login type which allows the most flexibility to connect to resources.
Prefer Kerberos over NTLM (using the negotiate provider) for authentication.